### PR TITLE
Point to creativechannel parse-javascript removing version req.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/ferlatte/parse-migrate.git"
   },
   "dependencies": {
-    "parse": "git+https://github.com/creativechannel/parse-javascript#1.4.2",
+    "parse": "git+https://github.com/creativechannel/parse-javascript",
     "optimist": "~0.6.0",
     "pkginfo": "~0.3.0",
     "mkdirp": "~0.3.5",


### PR DESCRIPTION
I think that removing the version will allow us to use the creativechannel/parse-javascript fork without having to explicitly update the version on each upgrade.